### PR TITLE
fix: self-host review issues — admin auth, JWT security, Docker hardening

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,7 @@ JWT_SECRET=change-me-to-a-random-string
 # --- Initial Admin Account ---
 INIT_ADMIN_EMAIL=admin@localhost
 INIT_ADMIN_PASSWORD=admin123
+# ADMIN_EMAILS=admin@localhost,other@example.com  # Comma-separated admin whitelist (defaults to INIT_ADMIN_EMAIL)
 
 # --- External APIs (optional, enables smart features) ---
 # OpenAI API — enables content compression in Context Load API

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,7 +70,7 @@ RUN addgroup --system --gid 1001 nodejs
 RUN adduser --system --uid 1001 nextjs
 
 # 复制公共资源
-COPY --from=builder /app/public ./public
+COPY --from=builder --chown=nextjs:nodejs /app/public ./public
 
 # 设置正确的权限
 RUN mkdir .next

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       - SKIP_EMAIL_VERIFICATION=true
       - INIT_ADMIN_EMAIL=${INIT_ADMIN_EMAIL:-admin@localhost}
       - INIT_ADMIN_PASSWORD=${INIT_ADMIN_PASSWORD:-admin123}
+      - ADMIN_EMAILS=${ADMIN_EMAILS:-}
       # --- Feature Flags (all local) ---
       - FF_USAGE_RECORD_LOCAL=true
       - FF_ACTIVITIES_LOCAL=true
@@ -29,12 +30,13 @@ services:
       - STRIPE_PUBLISHABLE_KEY=${STRIPE_PUBLISHABLE_KEY:-}
       # --- IM Server ---
       - IM_SERVER_ENABLED=true
-      - DATABASE_URL=mysql://prismer:prismer@mysql:3306/prismer_cloud
+      # NOTE: If MYSQL_PASSWORD contains URI-special chars (@, :, /, %), use REMOTE_MYSQL_* vars instead
+      - DATABASE_URL=mysql://${MYSQL_USER:-prismer}:${MYSQL_PASSWORD:-prismer}@mysql:3306/prismer_cloud
       # --- MySQL (for db.ts connection pool) ---
       - REMOTE_MYSQL_HOST=mysql
       - REMOTE_MYSQL_PORT=3306
-      - REMOTE_MYSQL_USER=prismer
-      - REMOTE_MYSQL_PASSWORD=prismer
+      - REMOTE_MYSQL_USER=${MYSQL_USER:-prismer}
+      - REMOTE_MYSQL_PASSWORD=${MYSQL_PASSWORD:-prismer}
       - REMOTE_MYSQL_DATABASE=prismer_cloud
       # --- App URL ---
       - NEXT_PUBLIC_BASE_URL=${NEXT_PUBLIC_BASE_URL:-http://localhost:3000}
@@ -59,8 +61,8 @@ services:
     environment:
       - MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD:-rootpass}
       - MYSQL_DATABASE=prismer_cloud
-      - MYSQL_USER=prismer
-      - MYSQL_PASSWORD=prismer
+      - MYSQL_USER=${MYSQL_USER:-prismer}
+      - MYSQL_PASSWORD=${MYSQL_PASSWORD:-prismer}
     ports:
       - "${MYSQL_PORT:-3306}:3306"
     volumes:

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -3,7 +3,7 @@
 set -e
 
 echo "[Entrypoint] Running Prisma db push for IM tables..."
-prisma db push --schema=prisma/schema.mysql.prisma --skip-generate --accept-data-loss 2>&1 || {
+prisma db push --schema=prisma/schema.mysql.prisma --skip-generate 2>&1 || {
   echo "[Entrypoint] WARNING: Prisma db push failed (may already be applied)"
 }
 

--- a/src/app/api/admin/analytics/route.ts
+++ b/src/app/api/admin/analytics/route.ts
@@ -3,7 +3,10 @@ import { ensureNacosConfig } from '@/lib/nacos-config';
 import { getUserFromAuth } from '@/lib/auth-utils';
 import { getAdminAnalytics } from '@/lib/db-admin';
 
-const ADMIN_EMAILS = ['tomwinshare@gmail.com'];
+/** Read after Nacos config is loaded (env vars may not be set at import time) */
+function getAdminEmails(): string[] {
+  return (process.env.ADMIN_EMAILS || '').split(',').map(e => e.trim()).filter(Boolean);
+}
 
 /**
  * GET /api/admin/analytics?period=7d|30d|90d
@@ -24,7 +27,11 @@ export async function GET(request: NextRequest) {
         { status: 401 }
       );
     }
-    if (!ADMIN_EMAILS.includes(auth.user.email)) {
+    const adminEmails = getAdminEmails();
+    const isAdmin = adminEmails.length > 0
+      ? adminEmails.includes(auth.user.email)
+      : auth.user.email === (process.env.INIT_ADMIN_EMAIL || 'admin@localhost');
+    if (!isAdmin) {
       return NextResponse.json(
         { success: false, error: { code: 'FORBIDDEN', message: 'Admin access only' } },
         { status: 403 }

--- a/src/im/auth/middleware.ts
+++ b/src/im/auth/middleware.ts
@@ -85,7 +85,7 @@ export async function authMiddleware(c: Context, next: Next) {
     c.set('user', {
       sub: adminUserId,
       username: process.env.INIT_ADMIN_EMAIL || 'admin@localhost',
-      role: 'human',
+      role: 'admin',
       imUserId: adminUserId,
       trustTier: 4,
       suspendedUntil: null,

--- a/src/lib/api-guard.ts
+++ b/src/lib/api-guard.ts
@@ -273,7 +273,12 @@ async function checkBalance(userId: string, estimatedCost: number): Promise<bool
 // ============================================================================
 
 function getJWTSecret(): string {
-  return process.env.JWT_SECRET || process.env.NEXTAUTH_SECRET || 'dev-secret-change-me';
+  const secret = process.env.JWT_SECRET || process.env.NEXTAUTH_SECRET;
+  if (!secret) {
+    console.error('[ApiGuard] JWT_SECRET is not set — using insecure fallback. Set JWT_SECRET in .env!');
+    return 'dev-secret-change-me';
+  }
+  return secret;
 }
 
 /**

--- a/src/lib/auth-utils.ts
+++ b/src/lib/auth-utils.ts
@@ -17,18 +17,24 @@ export interface AuthResult {
 }
 
 /**
- * 解析 JWT payload（不验证签名，仅解码）
- * 
- * 注意：生产环境应该验证签名，但由于我们的 JWT 是后端签发的，
- * 这里简化处理，信任已经通过网关的请求
+ * 解析并验证 JWT
+ *
+ * FF_AUTH_LOCAL=true 时验证签名（self-host 无网关，必须本地验证）
+ * FF_AUTH_LOCAL=false 时仅解码（信任已经通过后端网关的请求）
  */
 function decodeJwtPayload(token: string): Record<string, unknown> | null {
   try {
-    // JWT 格式: header.payload.signature
+    if (process.env.FF_AUTH_LOCAL === 'true') {
+      // Self-host: verify signature locally
+      const secret = process.env.JWT_SECRET || process.env.NEXTAUTH_SECRET;
+      if (secret) {
+        const jwt = require('jsonwebtoken');
+        return jwt.verify(token, secret) as Record<string, unknown>;
+      }
+    }
+    // Cloud mode: decode only (trust gateway)
     const parts = token.split('.');
     if (parts.length !== 3) return null;
-    
-    // Base64Url 解码 payload
     const payload = parts[1];
     const decoded = Buffer.from(payload, 'base64url').toString('utf-8');
     return JSON.parse(decoded);


### PR DESCRIPTION
## Summary

Fixes 9 issues found during code review (Claude + Codex) of the self-host feature:

- **Admin analytics 403 in self-host**: `ADMIN_EMAILS` was hardcoded to a personal email; now reads from env var with fallback to `INIT_ADMIN_EMAIL`
- **IM admin routes 403**: `AUTH_DISABLED` mode set `role: 'human'` but `adminGuard` requires `role: 'admin'`
- **`--accept-data-loss` on every restart**: Removed from `prisma db push` in docker-entrypoint to prevent silent data loss on upgrades
- **JWT fallback secret**: Logs error when `JWT_SECRET` is missing instead of silently using hardcoded string
- **JWT signature not verified in self-host**: `auth-utils.ts` now verifies JWT signature when `FF_AUTH_LOCAL=true`
- **MySQL credentials hardcoded**: `docker-compose.yml` now uses `${MYSQL_USER}` / `${MYSQL_PASSWORD}` interpolation
- **Dockerfile `public/` permissions**: Added `--chown=nextjs:nodejs` for consistency
- **`ADMIN_EMAILS` read at import time**: Changed to lazy function call so Nacos config is loaded first
- **DATABASE_URL URI encoding**: Added comment warning about special characters in MySQL password

## Test plan

- [ ] `docker compose up -d` with default config still works
- [ ] Admin analytics endpoint accessible with default admin email
- [ ] IM admin routes (`/api/im/admin/users/:id/trust-tier`) accessible in AUTH_DISABLED mode
- [ ] Custom `MYSQL_USER`/`MYSQL_PASSWORD` in `.env` propagates correctly
- [ ] Container restart does not lose IM data (no `--accept-data-loss`)

🤖 Generated with [Claude Code](https://claude.ai/code)