### PR TITLE
feat: add Exa AI-powered search tracking header

### DIFF
--- a/server/src/app/api/content/route.ts
+++ b/server/src/app/api/content/route.ts
@@ -95,6 +95,7 @@ export async function POST(request: NextRequest) {
     }
 
     const contentClient = new Exa(CONTENT_API_KEY);
+    (contentClient as any).headers.set('x-exa-integration', 'prismercloud');
 
     console.log(`[Content API] Fetching content for ${urls.length} URL(s):`, urls);
 

--- a/server/src/app/api/search/route.ts
+++ b/server/src/app/api/search/route.ts
@@ -59,6 +59,7 @@ export async function POST(request: NextRequest) {
     }
 
     const searchClient = new Exa(SEARCH_API_KEY);
+    (searchClient as any).headers.set('x-exa-integration', 'prismercloud');
 
     // Strict configuration as specified
     // Request 15 results to have buffer after filtering low-quality ones


### PR DESCRIPTION
## Summary

- Adds `x-exa-integration: prismercloud` header to both Exa API clients (`/api/search` and `/api/content`)
- This allows Exa to attribute API usage to the PrismerCloud integration for analytics and partnership tracking
- Zero behavior change; only adds one header per client instantiation

## Files changed

- `server/src/app/api/search/route.ts` — added integration header after Exa client init
- `server/src/app/api/content/route.ts` — added integration header after Exa client init

## Code example

```ts
const searchClient = new Exa(SEARCH_API_KEY);
(searchClient as any).headers.set('x-exa-integration', 'prismercloud');
```

The `as any` cast is needed because `headers` is marked `private` in the exa-js type definitions, but is a standard `Headers` instance at runtime.

## Test plan

- [ ] Verify `/api/search` returns results as before
- [ ] Verify `/api/content` returns content as before
- [ ] Confirm `x-exa-integration` header is present in outgoing requests (visible in Exa dashboard or network logs)