### PR TITLE
fix(self-host): redact leaked API keys from v1.9.x sync

### DIFF
--- a/server/scripts/benchmark-api-latency.ts
+++ b/server/scripts/benchmark-api-latency.ts
@@ -32,8 +32,8 @@ const BASE_URLS: Record<string, string> = {
 };
 
 const API_KEYS: Record<string, string> = {
-  test: 'sk-prismer-live-8203d352cc8d2b41d17efe877b4b9c9420afd1e89666b5b0ae7161e80c39acd2',
-  prod: 'sk-prismer-live-dea50222cb9aec9eca33f2e947d9f49dbb4a719cae8b58ce9e197290302e5f06',
+  test: 'sk-prismer-live-REDACTED-SET-VIA-ENV',
+  prod: 'sk-prismer-live-REDACTED-SET-VIA-ENV',
 };
 
 const BASE = process.env.BASE_URL || BASE_URLS[ENV] || BASE_URLS.test;

--- a/server/scripts/benchmark-evolution-competitive.ts
+++ b/server/scripts/benchmark-evolution-competitive.ts
@@ -37,8 +37,8 @@ const BASE_URLS: Record<string, string> = {
   prod: 'https://prismer.cloud',
 };
 const API_KEYS: Record<string, string> = {
-  test: 'sk-prismer-live-8203d352cc8d2b41d17efe877b4b9c9420afd1e89666b5b0ae7161e80c39acd2',
-  prod: 'sk-prismer-live-dea50222cb9aec9eca33f2e947d9f49dbb4a719cae8b58ce9e197290302e5f06',
+  test: 'sk-prismer-live-REDACTED-SET-VIA-ENV',
+  prod: 'sk-prismer-live-REDACTED-SET-VIA-ENV',
 };
 
 const BASE = process.env.BASE_URL || BASE_URLS[ENV] || BASE_URLS.test;

--- a/server/scripts/benchmark-evolution-h2h.ts
+++ b/server/scripts/benchmark-evolution-h2h.ts
@@ -19,7 +19,7 @@
  */
 
 const PRISMER_BASE = 'https://cloud.prismer.dev';
-const PRISMER_KEY = 'sk-prismer-live-8203d352cc8d2b41d17efe877b4b9c9420afd1e89666b5b0ae7161e80c39acd2';
+const PRISMER_KEY = 'sk-prismer-live-REDACTED-SET-VIA-ENV';
 const EVOMAP_BASE = 'https://evomap.ai';
 
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));

--- a/server/scripts/benchmark-im.ts
+++ b/server/scripts/benchmark-im.ts
@@ -21,7 +21,7 @@ import WebSocket from 'ws';
 
 const BASE = process.env.PRISMER_BENCHMARK_URL || 'https://prismer.cloud';
 const API_KEY =
-  process.env.PRISMER_API_KEY || 'sk-prismer-live-dea50222cb9aec9eca33f2e947d9f49dbb4a719cae8b58ce9e197290302e5f06';
+  process.env.PRISMER_API_KEY || 'sk-prismer-live-REDACTED-SET-VIA-ENV';
 
 interface M {
   name: string;

--- a/server/scripts/ga-smoke.sh
+++ b/server/scripts/ga-smoke.sh
@@ -22,7 +22,7 @@ set -uo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$REPO_ROOT"
 
-DEV_KEY="sk-prismer-live-a2ec8ab7966295e2f1ed1817f571e10b9470e96cd8156325497ff2eee3e25842"
+DEV_KEY="sk-prismer-live-REDACTED-SET-VIA-ENV"
 CLOUD_BASE="http://127.0.0.1:3000"
 NEXT_LOG="$REPO_ROOT/.dev-stack/next.log"
 SMOKE_DIR="$REPO_ROOT/.dev-stack/smoke"

--- a/server/scripts/import-gstack-skills.ts
+++ b/server/scripts/import-gstack-skills.ts
@@ -29,7 +29,7 @@ const BASE_URL = ENV_MAP[envArg] || ENV_MAP.test;
 const API_KEY =
   process.env.PRISMER_API_KEY ||
   process.env.PRISMER_API_KEY_TEST ||
-  'sk-prismer-live-8203d352cc8d2b41d17efe877b4b9c9420afd1e89666b5b0ae7161e80c39acd2';
+  'sk-prismer-live-REDACTED-SET-VIA-ENV';
 
 // Use /api/im/ prefix for Next.js proxy, /api/ for standalone
 const API_PREFIX = BASE_URL.includes('localhost:3200') ? '/api' : '/api/im';

--- a/server/scripts/import-gstack-to-skills.ts
+++ b/server/scripts/import-gstack-to-skills.ts
@@ -31,10 +31,10 @@ const BASE_URL = ENV_MAP[envArg] || ENV_MAP.test;
 
 const API_KEY =
   envArg === 'prod'
-    ? process.env.PRISMER_API_KEY || 'sk-prismer-live-dea50222cb9aec9eca33f2e947d9f49dbb4a719cae8b58ce9e197290302e5f06'
+    ? process.env.PRISMER_API_KEY || 'sk-prismer-live-REDACTED-SET-VIA-ENV'
     : process.env.PRISMER_API_KEY_TEST ||
       process.env.PRISMER_API_KEY ||
-      'sk-prismer-live-8203d352cc8d2b41d17efe877b4b9c9420afd1e89666b5b0ae7161e80c39acd2';
+      'sk-prismer-live-REDACTED-SET-VIA-ENV';
 
 const API_PREFIX = BASE_URL.includes('localhost:3200') ? '/api' : '/api/im';
 

--- a/server/scripts/regression-v182-reactions.ts
+++ b/server/scripts/regression-v182-reactions.ts
@@ -18,7 +18,7 @@
 const BASE = process.env.PRISMER_BASE_URL || 'https://cloud.prismer.dev';
 const API_KEY =
   process.env.PRISMER_API_KEY_TEST ||
-  'sk-prismer-live-8203d352cc8d2b41d17efe877b4b9c9420afd1e89666b5b0ae7161e80c39acd2';
+  'sk-prismer-live-REDACTED-SET-VIA-ENV';
 
 interface TestResult {
   name: string;

--- a/server/scripts/sdk-evaluation.ts
+++ b/server/scripts/sdk-evaluation.ts
@@ -17,7 +17,7 @@ import { extractMeta } from '../src/lib/context-meta';
 const BASE = process.env.PRISMER_BASE_URL || 'https://cloud.prismer.dev';
 const API_KEY =
   process.env.PRISMER_API_KEY_TEST ||
-  'sk-prismer-live-8203d352cc8d2b41d17efe877b4b9c9420afd1e89666b5b0ae7161e80c39acd2';
+  'sk-prismer-live-REDACTED-SET-VIA-ENV';
 
 let passed = 0;
 let failed = 0;

--- a/server/scripts/stress-test-context-api.js
+++ b/server/scripts/stress-test-context-api.js
@@ -80,7 +80,7 @@ if (args.includes('--help') || args.includes('-h') || args.length === 0) {
 }
 
 // Configuration
-const API_KEY = process.env.PRISMER_API_KEY || 'sk-prismer-live-0fd2b6c622d189695f2255cb43d86fb9e4a6211eac952c382b03ab4ad340cf86';
+const API_KEY = process.env.PRISMER_API_KEY || 'sk-prismer-live-REDACTED-SET-VIA-ENV';
 const isLocal = args.includes('--local');
 const API_BASE = process.env.PRISMER_API_BASE || (isLocal ? 'http://localhost:3000' : 'https://prismer.cloud');
 

--- a/server/scripts/test-all-apis.ts
+++ b/server/scripts/test-all-apis.ts
@@ -39,8 +39,8 @@ const BASE_URLS: Record<string, string> = {
 };
 
 const API_KEYS: Record<string, string> = {
-  test: 'sk-prismer-live-8203d352cc8d2b41d17efe877b4b9c9420afd1e89666b5b0ae7161e80c39acd2',
-  prod: 'sk-prismer-live-dea50222cb9aec9eca33f2e947d9f49dbb4a719cae8b58ce9e197290302e5f06',
+  test: 'sk-prismer-live-REDACTED-SET-VIA-ENV',
+  prod: 'sk-prismer-live-REDACTED-SET-VIA-ENV',
 };
 
 const BASE = process.env.BASE_URL || BASE_URLS[ENV] || BASE_URLS.local;

--- a/server/scripts/test-evolution-e2e.ts
+++ b/server/scripts/test-evolution-e2e.ts
@@ -26,12 +26,12 @@ const BASE = BASE_URLS[envFlag] || BASE_URLS.local;
 // Test API keys (from CLAUDE.md)
 const API_KEYS: Record<string, string> = {
   local:
-    process.env.PRISMER_API_KEY || 'sk-prismer-live-dea50222cb9aec9eca33f2e947d9f49dbb4a719cae8b58ce9e197290302e5f06',
+    process.env.PRISMER_API_KEY || 'sk-prismer-live-REDACTED-SET-VIA-ENV',
   test:
     process.env.PRISMER_API_KEY_TEST ||
-    'sk-prismer-live-8203d352cc8d2b41d17efe877b4b9c9420afd1e89666b5b0ae7161e80c39acd2',
+    'sk-prismer-live-REDACTED-SET-VIA-ENV',
   prod:
-    process.env.PRISMER_API_KEY || 'sk-prismer-live-dea50222cb9aec9eca33f2e947d9f49dbb4a719cae8b58ce9e197290302e5f06',
+    process.env.PRISMER_API_KEY || 'sk-prismer-live-REDACTED-SET-VIA-ENV',
 };
 const API_KEY = API_KEYS[envFlag] || API_KEYS.local;
 

--- a/server/scripts/test-full-flow.mjs
+++ b/server/scripts/test-full-flow.mjs
@@ -20,7 +20,7 @@
  */
 
 const BASE = 'https://prismer.cloud';
-const API_KEY = 'sk-prismer-live-fa3b964f6e52fe63c33bbef562aa13bfa9c5520416c3c49528c8e76b35dd5c03';
+const API_KEY = 'sk-prismer-live-REDACTED-SET-VIA-ENV';
 
 let passed = 0;
 let failed = 0;

--- a/server/scripts/test-im-stress.ts
+++ b/server/scripts/test-im-stress.ts
@@ -47,8 +47,8 @@ const WS_URLS: Record<string, string> = {
 };
 
 const API_KEYS: Record<string, string> = {
-  test: 'sk-prismer-live-8203d352cc8d2b41d17efe877b4b9c9420afd1e89666b5b0ae7161e80c39acd2',
-  prod: 'sk-prismer-live-dea50222cb9aec9eca33f2e947d9f49dbb4a719cae8b58ce9e197290302e5f06',
+  test: 'sk-prismer-live-REDACTED-SET-VIA-ENV',
+  prod: 'sk-prismer-live-REDACTED-SET-VIA-ENV',
 };
 
 const BASE = BASE_URLS[ENV];

--- a/server/scripts/test-skill-coverage.ts
+++ b/server/scripts/test-skill-coverage.ts
@@ -8,7 +8,7 @@
 const BASE = 'https://cloud.prismer.dev';
 const API_KEY =
   process.env.PRISMER_API_KEY_TEST ||
-  'sk-prismer-live-8203d352cc8d2b41d17efe877b4b9c9420afd1e89666b5b0ae7161e80c39acd2';
+  'sk-prismer-live-REDACTED-SET-VIA-ENV';
 
 let passed = 0;
 let failed = 0;

--- a/server/scripts/test-v180-regression.ts
+++ b/server/scripts/test-v180-regression.ts
@@ -25,8 +25,8 @@ const BASE_URLS: Record<string, string> = {
 };
 
 const API_KEYS: Record<string, string> = {
-  test: 'sk-prismer-live-8203d352cc8d2b41d17efe877b4b9c9420afd1e89666b5b0ae7161e80c39acd2',
-  prod: 'sk-prismer-live-dea50222cb9aec9eca33f2e947d9f49dbb4a719cae8b58ce9e197290302e5f06',
+  test: 'sk-prismer-live-REDACTED-SET-VIA-ENV',
+  prod: 'sk-prismer-live-REDACTED-SET-VIA-ENV',
 };
 
 const BASE = process.env.BASE_URL || BASE_URLS[ENV] || BASE_URLS.local;

--- a/server/scripts/test-v182-regression.ts
+++ b/server/scripts/test-v182-regression.ts
@@ -28,8 +28,8 @@ const BASE_URLS: Record<string, string> = {
   prod: 'https://prismer.cloud',
 };
 const API_KEYS: Record<string, string> = {
-  test: 'sk-prismer-live-8203d352cc8d2b41d17efe877b4b9c9420afd1e89666b5b0ae7161e80c39acd2',
-  prod: 'sk-prismer-live-dea50222cb9aec9eca33f2e947d9f49dbb4a719cae8b58ce9e197290302e5f06',
+  test: 'sk-prismer-live-REDACTED-SET-VIA-ENV',
+  prod: 'sk-prismer-live-REDACTED-SET-VIA-ENV',
 };
 
 const BASE = BASE_URLS[argEnv] || BASE_URLS.local;


### PR DESCRIPTION
## Summary
- Replace 5 hardcoded `sk-prismer-live-<hex>` literals across 17 `server/scripts/*` files with `sk-prismer-live-REDACTED-SET-VIA-ENV` placeholder.
- Same pattern as 139137e (v1.7.4 → v1.8.2 sync fix), which did not propagate because `build/sync-server/content-scrub.txt` was updated downstream of the v1.9.x sync run.

## Background
PR #51 (merged as e8e21ca) shipped with GitGuardian failing. The 5 leaked keys are now in main's git history:

| Key (prefix) | First seen |
|---|---|
| `sk-prismer-live-8203d352…` | `benchmark-*`, `test-*`, `import-*` (test env) |
| `sk-prismer-live-dea50222…` | `benchmark-*`, `test-*` (prod env) |
| `sk-prismer-live-a2ec8ab7…` | `ga-smoke.sh` (DEV_KEY) |
| `sk-prismer-live-0fd2b6c6…` | `stress-test-context-api.js` |
| `sk-prismer-live-fa3b964f…` | `test-full-flow.mjs` |

The `0000…0000` placeholder in `test-all-apis.ts:211` and `test-security.ts:127` is intentionally untouched — it's a fake key used to assert 401 behavior.

## Files changed (17)
All under `server/scripts/`:
- benchmark-api-latency.ts, benchmark-evolution-competitive.ts, benchmark-evolution-h2h.ts, benchmark-im.ts
- ga-smoke.sh
- import-gstack-skills.ts, import-gstack-to-skills.ts
- regression-v182-reactions.ts, sdk-evaluation.ts
- stress-test-context-api.js
- test-all-apis.ts, test-evolution-e2e.ts, test-full-flow.mjs, test-im-stress.ts
- test-skill-coverage.ts, test-v180-regression.ts, test-v182-regression.ts

## Test plan
- [ ] GitGuardian Security Checks pass (was failing on PR #51, this is the whole point)
- [ ] Build / Lint & Type Check / Docker Build still green (no logic change, only string literal substitution)
- [ ] Rotate the 5 real keys in prismer.cloud admin (cannot be done by this PR — history was already indexed by GitGuardian)

## Follow-up (not in this PR)
- Add fail-fast `if (!API_KEY) process.exit(1)` to scripts that previously used a baked-in literal as the sole source — see 139137e style.
- Update `build/sync-server/content-scrub.txt` in the closed-source repo so future syncs auto-strip this shape.
- Sync the `docs/` refactor from `feat/refactoring` (separate PR).